### PR TITLE
Add Formatting with `clang-format`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,10 @@
+---
+BasedOnStyle: LLVM
+ColumnLimit: '80'
+IncludeBlocks: Regroup
+IndentWidth: '4'
+Language: Cpp
+SortIncludes: 'true'
+UseTab: Never
+
+...

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,12 @@
+name: clang-format
+run-name: ${{ github.actor }}
+on: [push, pull_request]
+jobs:
+  format-code:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: install clang-format
+        run: sudo apt update && sudo apt install -y clang-format
+      - name: check formatting
+        run: chmod +x check_format.sh && ./check_format.sh

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ log.txt
 **/.*
 !.gitignore
 !.github
+!.clang-format

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ ASM_OS_ENTRY_SOURCE=./src/boot/os_entry.asm
 BOOT_OBJ := boot.o
 OS_BIN := mOS.bin
 
+C_FILES = $(shell find -name '*.[ch]')
+
 OBJ_NAMES := src/os/main.o src/os/test.o os_entry.o src/lib/video/VGA_text.o \
 	src/os/hard/idt.o src/os/hard/except.o src/os/hard/pic.o \
 	src/lib/device/serial.o src/lib/container/ring_buffer.o \
@@ -40,6 +42,11 @@ qemu: $(OS_BIN)
 test: $(OS_BIN)
 	cd tests && $(MAKE) clean
 	cd tests && $(MAKE) test
+
+format: $(C_FILES)
+	for file in $?; do \
+		clang-format -i $$file && echo "formatted $$file"; \
+	done
 
 clean:
 	rm -f mOS

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ For contributing _fork_ this repository and then make your changes in the form o
 ### Running
  * run `make qemu` in the root directory of the project
 
+### Formatting
+ * run `make format` in the root directory of the project to format the code
+   according to the formatter in .clang-format
+
 ## General behavior
 boot and immediately drop to a prompt.
 programs can be executed from the prompt.

--- a/check_format.sh
+++ b/check_format.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+FILES=$(find -name "*.[ch]")
+
+for file in $FILES; do
+    echo $file;
+    clang-format $file > temp && diff $file temp && rm temp;
+    if [[ $? != 0 ]]
+    then
+        exit 1;
+    fi
+done


### PR DESCRIPTION
# Description

- formats all .c and .h files on `make format`
- added additional formatting specs in `.clang-format`
- added directions for formatting code in `README.md`

It's super easy to change formatting, just change `.clang-format` and run `make format` again!

Issue #21 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

### Testing 
Please describe tests that you ran to verify your changes. Provide instructions so that we can reproduce. Please also list any relevant details for your test configuration.

**Test Configuration**:
* Hardware
* OS

All existing tests pass AFTER formatting is run.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
