### PR TITLE
More robust interrupts

### DIFF
--- a/src/lib/device/serial.c
+++ b/src/lib/device/serial.c
@@ -121,14 +121,14 @@ void serialSetBaud(uint16_t port, uint16_t baud) {
 /* read related functions */
 
 uint8_t serialReadByte(uint16_t port) {
-    disableInterrupts();
+    InterruptState iprev = disableInterrupts();
     uint8_t out;
     if (port == COM1) {
         out = ring_buffer_pop(&inCOM1);
     } else {
         out = ring_buffer_pop(&inCOM2);
     }
-    enableInterrupts();
+    setInterrupts(iprev);
     return out;
 }
 uint8_t serialReadByteBlocking(uint16_t port) {
@@ -183,8 +183,8 @@ void serialWriteBlocking(uint16_t port, uint8_t *data, size_t n) {
 
 // sends n bytes over serial, non-blocking
 void serialWrite(uint16_t port, uint8_t *data, size_t n) {
-    disableInterrupts();  // disable cpu interrupts
-    outb(port + 1, 0b00); // disable serial interrupts
+    InterruptState iprev = disableInterrupts(); // disable cpu interrupts
+    outb(port + 1, 0b00);                       // disable serial interrupts
 
     if (port == COM1) {
         outCOM1 = data;
@@ -194,7 +194,7 @@ void serialWrite(uint16_t port, uint8_t *data, size_t n) {
         remainCOM2 = n;
     }
 
-    enableInterrupts();
+    setInterrupts(iprev);
     outb(port + 1, DR_INT | THRE_INT); // enable serial interrupts
 }
 

--- a/src/lib/pit/pit.c
+++ b/src/lib/pit/pit.c
@@ -15,11 +15,11 @@ static void timer_handler(isr_registers_t *regs) {
 }
 
 void init_pit() {
-    disableInterrupts();
+    InterruptState iprev = disableInterrupts();
     irqSetHandler(0, timer_handler);
     init_timer(
         100); // 100 hz is just a good general frequency according to the wiki
-    enableInterrupts();
+    setInterrupts(iprev);
 }
 
 void init_timer(int hz) {

--- a/src/os/hard/idt.h
+++ b/src/os/hard/idt.h
@@ -45,7 +45,17 @@ typedef void (*int_handler_t)(isr_registers_t *);
 void isrSetHandler(uint8_t isr_vec, int_handler_t handler);
 void irqSetHandler(uint8_t irq_vec, int_handler_t handler);
 
-void disableInterrupts(void);
-void enableInterrupts(void);
+typedef enum {
+    InterruptOn,
+    InterruptOff,
+} InterruptState;
+
+// get current state of interrupts
+InterruptState getInterrupts(void);
+
+// returns the previous state
+InterruptState disableInterrupts(void);
+InterruptState enableInterrupts(void);
+InterruptState setInterrupts(InterruptState state);
 
 #endif


### PR DESCRIPTION

# Description

A lot of these functions would enable interrupts when they really just wanted to go back to the original interrupt state. This change allows that to occur. Based on how PintOS does it.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

### Testing 
Current tests pass.

**Test Configuration**:
* qemu 7.2.0 on Windows 10 with WSL 5.10.16.3 running Ubuntu 20.04
* python 3.10.10

# Checklist:
	
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
