### PR TITLE
Fix MacOS Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DEBUG ?= false # lowers optimization levels and increases command verbosity
 ifeq ($(PLATFORM), Darwin) 
 CC := x86_64-elf-gcc
 LD := x86_64-elf-ld
-OBJCOPY := x86_64-objcopy
+OBJCOPY := x86_64-elf-objcopy
 else
 CC := gcc
 LD := ld

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,9 @@ export DEBUG_CFLAGS
 export DEBUG_NASM_FLAGS
 export DEBUG_QEMU_FLAGS
 
-export CFLAGS := -Wall -Werror $(DEBUG_CFLAGS) -Wl,--oformat=binary -no-pie -m32 -s -falign-functions=4 -ffreestanding -fno-asynchronous-unwind-tables
+export CFLAGS := -Wall -Werror $(DEBUG_CFLAGS) -Wl,--oformat=binary -no-pie -m32 -mno-mmx -mno-sse -mno-sse2 -mno-sse3 \
+					-s -falign-functions=4 -ffreestanding -fno-asynchronous-unwind-tables
+
 export LFLAGS := -melf_i386 --build-id=none
 
 ASM_BOOT_SECT_SOURCE := ./src/boot/boot_sect.asm

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ PLATFORM := $(shell uname)
 DEBUG ?= false # lowers optimization levels and increases command verbosity
 
 ifeq ($(PLATFORM), Darwin) 
-CC := i386-elf-gcc
-LD := i386-elf-ld
-OBJCOPY := gobjcopy
+CC := x86_64-elf-gcc
+LD := x86_64-elf-ld
+OBJCOPY := x86_64-objcopy
 else
 CC := gcc
 LD := ld

--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ For contributing _fork_ this repository and then make your changes in the form o
 Use homebrew to install the dependencies using these commands:
 
 ```shell
-brew link --overwrite i386-elf-binutils
-brew install i386-elf-binutils i386-elf-gcc nasm binutils qemu
+brew install x86_64-elf-binutils x86_64-elf-gcc nasm binutils qemu
 ```
 
 If you are on Apple Silicon, you will need to use Rosetta along with installing x86_64 libraries. This can be done by prefixing the previous commands with `arch -x86_64`.
@@ -55,6 +54,11 @@ You will need to ensure that these programs are on your PATH or `make` will not 
 ### Running
 
 * run `make qemu` in the root directory of the project
+
+### Debugging
+
+* run `make qemu-gdb` in the root directory of the project
+* run `make qemu-gdb-boot` in the root directory for debugging the bootloader
 
 ### Running in DEBUG mode
 


### PR DESCRIPTION
# Description

The previous change had an issue with the cross-compiler and tools.
Specifically, `i386-...` no longer exists and instead installs `x86_64-...`
This change fixes the brew commands and updates the Makefile

Issue #40 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

### Testing 
I cannot physically test this myself.

# Checklist:
	
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
