### PR TITLE
Type-agnostic sorting (insertion sort)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ os_entry.o: $(ASM_OS_ENTRY_SOURCE)
 	nasm $^ -f elf32 -o $@ $(DEBUG_NASM_FLAGS)
 
 %.o: %.c
-	$(CC) -c $^ -o $@ $(CFLAGS) -I./src/lib/
+	$(CC) -c $^ -o $@ $(CFLAGS) -I./src/lib/ -I./src/lib/stdlib/
 
 %.o: %.asm
 	nasm $^ -f elf32 -o $@ $(DEBUG_NASM_FLAGS)

--- a/src/lib/stdlib/stdlib.c
+++ b/src/lib/stdlib/stdlib.c
@@ -82,18 +82,19 @@ void itoa_s(int in, char *buf, int bufsz) {
         buf[i] = '\0';
 }
 
-void isort(void *base, size_t nel, size_t width, int (*compar)(const void *a, const void *b) ) {
+void isort(void *base, size_t nel, size_t width,
+           int (*compar)(const void *a, const void *b)) {
     if (nel < 2 || width < 1) {
         return;
     }
 
     for (int i = 0; i < nel; i++) {
-        for (int j = i+1; j < nel; j++) {
+        for (int j = i + 1; j < nel; j++) {
 
             void *a = base + i * width;
             void *b = base + j * width;
 
-            if (compar(a, b) > 0) { 
+            if (compar(a, b) > 0) {
                 memswap(a, b, width);
             }
         }

--- a/src/lib/stdlib/stdlib.c
+++ b/src/lib/stdlib/stdlib.c
@@ -81,3 +81,33 @@ void itoa_s(int in, char *buf, int bufsz) {
     if (bufsz != 0)
         buf[i] = '\0';
 }
+
+// Implements insertion sort
+// 
+// parameters:
+//   void *base:      base pointer for array
+//   size_t nel:      array length
+//   size_t width:    sizeof array type
+//   int (*compar)(const void *a, const void *b): comparison function between two void * values
+
+void isort(void *base, size_t nel, size_t width, int (*compar)(const void *a, const void *b) ) {
+
+    if (nel == 0 || nel == 1) {
+        return;
+    }
+
+    for (int i = 0; i < nel; i++) {
+        for (int j = i+1; j < nel; j++) {
+
+            void *a = base + i * width;
+            void *b = base + j * width;
+
+            if (compar(a, b) == 1) { 
+                char temp_b[width];
+                memcpy(temp_b, b, width);
+                memcpy(b, a, width);
+                memcpy(a, temp_b, width);
+            }
+        }
+    }
+}

--- a/src/lib/stdlib/stdlib.c
+++ b/src/lib/stdlib/stdlib.c
@@ -82,17 +82,8 @@ void itoa_s(int in, char *buf, int bufsz) {
         buf[i] = '\0';
 }
 
-// Implements insertion sort
-// 
-// parameters:
-//   void *base:      base pointer for array
-//   size_t nel:      array length
-//   size_t width:    sizeof array type
-//   int (*compar)(const void *a, const void *b): comparison function between two void * values
-
 void isort(void *base, size_t nel, size_t width, int (*compar)(const void *a, const void *b) ) {
-
-    if (nel == 0 || nel == 1) {
+    if (nel < 2 || width < 1) {
         return;
     }
 
@@ -102,11 +93,8 @@ void isort(void *base, size_t nel, size_t width, int (*compar)(const void *a, co
             void *a = base + i * width;
             void *b = base + j * width;
 
-            if (compar(a, b) == 1) { 
-                char temp_b[width];
-                memcpy(temp_b, b, width);
-                memcpy(b, a, width);
-                memcpy(a, temp_b, width);
+            if (compar(a, b) > 0) { 
+                memswap(a, b, width);
             }
         }
     }

--- a/src/lib/stdlib/stdlib.h
+++ b/src/lib/stdlib/stdlib.h
@@ -10,5 +10,11 @@ void itoa_s(int i, char *buf, int bufsz);
 //   size_t nel:      array length
 //   size_t width:    sizeof array type
 //   int (*compar)(const void *a, const void *b): comparison function between two void * values
+//
+// compar function:
+//   3-way comparison:
+//   - if a comes before b, return -1
+//   - if a is equivilent to b, return 0
+//   - if a comes after b, return 1
 
 void isort(void *base, size_t nel, size_t width, int (*compar)(const void *a, const void *b));

--- a/src/lib/stdlib/stdlib.h
+++ b/src/lib/stdlib/stdlib.h
@@ -4,12 +4,13 @@ int atoi(const char *str);
 void itoa_s(int i, char *buf, int bufsz);
 
 // Implements insertion sort
-// 
+//
 // parameters:
 //   void *base:      base pointer for array
 //   size_t nel:      array length
 //   size_t width:    sizeof array type
-//   int (*compar)(const void *a, const void *b): comparison function between two void * values
+//   int (*compar)(const void *a, const void *b): comparison function between
+//   two void * values
 //
 // compar function:
 //   3-way comparison:
@@ -17,4 +18,5 @@ void itoa_s(int i, char *buf, int bufsz);
 //   - if a is equivilent to b, return 0
 //   - if a comes after b, return 1
 
-void isort(void *base, size_t nel, size_t width, int (*compar)(const void *a, const void *b));
+void isort(void *base, size_t nel, size_t width,
+           int (*compar)(const void *a, const void *b));

--- a/src/lib/stdlib/stdlib.h
+++ b/src/lib/stdlib/stdlib.h
@@ -2,3 +2,13 @@
 
 int atoi(const char *str);
 void itoa_s(int i, char *buf, int bufsz);
+
+// Implements insertion sort
+// 
+// parameters:
+//   void *base:      base pointer for array
+//   size_t nel:      array length
+//   size_t width:    sizeof array type
+//   int (*compar)(const void *a, const void *b): comparison function between two void * values
+
+void isort(void *base, size_t nel, size_t width, int (*compar)(const void *a, const void *b));

--- a/src/lib/stdlib/string.c
+++ b/src/lib/stdlib/string.c
@@ -62,3 +62,15 @@ void memset(void *restrict dest, uint8_t c, size_t n) {
         ((uint8_t *)dest)[i] = c;
     }
 }
+
+void memswap(void *restrict src_a, void *restrict src_b, size_t n) {
+    char *a = (char *)src_a;
+    char *b = (char *)src_b;
+    for (int i = 0; i < n; i++) {
+        char swap_a = a[i];
+        char swap_b = b[i];
+
+        a[i] = swap_b;
+        b[i] = swap_a; 
+    }
+}

--- a/src/lib/stdlib/string.c
+++ b/src/lib/stdlib/string.c
@@ -71,6 +71,6 @@ void memswap(void *restrict src_a, void *restrict src_b, size_t n) {
         char swap_b = b[i];
 
         a[i] = swap_b;
-        b[i] = swap_a; 
+        b[i] = swap_a;
     }
 }

--- a/src/lib/stdlib/string.h
+++ b/src/lib/stdlib/string.h
@@ -6,3 +6,4 @@ char *strcpy_s(char *restrict dest, size_t destsz, const char *restrict src);
 int strncmp(const char *s1, const char *s2, size_t n);
 void *memcpy(void *restrict dest, void *restrict src, size_t n);
 void memset(void *restrict dest, uint8_t c, size_t n);
+void memswap(void *restrict src_a, void *restrict src_b, size_t n);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,7 +14,7 @@ all: $(MOS_ELF) $(BIN_NAMES)
 	rm $@.elf
 
 %.o: %.c
-	$(CC) -c $^ -o $@ $(CFLAGS) -I./../src/lib/
+	$(CC) -c $^ -o $@ $(CFLAGS) -I./../src/lib/ -I./../src/lib/stdlib/
 
 test_entry.o: test_entry.asm
 	nasm $^ -f elf32 -o $@

--- a/tests/expected/lib/stdlib/test_sort.expect
+++ b/tests/expected/lib/stdlib/test_sort.expect
@@ -1,0 +1,3 @@
+test_integer_sort done
+test_struct_sort done
+test_sort done

--- a/tests/src/lib/stdlib/test_sort.c
+++ b/tests/src/lib/stdlib/test_sort.c
@@ -1,0 +1,107 @@
+#include <stddef.h>
+#include <stdint.h>
+#include "../../test_helper.h"
+#include "stdlib/stdlib.h"
+#include "stdlib/string.h"
+
+void verify_sorted(void *base, size_t nel, size_t width, int (*compar)(const void *a, const void *b)) {
+    ASSERT(nel >= 0);
+    ASSERT(width > 0);
+  
+    if (nel == 0 || nel == 1) return;
+
+    for (int i = 0; i < nel - 1; i++) {
+        void *a = base + i * width;
+        void *b = base + (i+1) * width;
+        ASSERT(compar(a, b) < 1);
+    }
+}
+
+void verify_expected(void *base_a, void *base_b, size_t nel, size_t width) {
+    char *a = (char *)base_a;
+    char *b = (char *)base_b;
+    for (int i = 0; i < nel * width; i++) {
+        if (a[i] != b[i]) ASSERT(0);
+        return;
+    }
+}
+
+int intcmpfunc(const void *a, const void *b) {
+    int val_a = *(int *)a;
+    int val_b = *(int *)b;
+    if (val_a < val_b) return -1;
+    else if (val_a == val_b) return 0;
+    return 1;
+}
+
+typedef struct {
+    char c;
+    uint32_t i;
+    double d;
+} Type;
+
+int cmpfunc(const void *a, const void *b) {
+    Type val_a = *(Type *)a;
+    Type val_b = *(Type *)b;
+    if (val_a.c < val_b.c) return -1;
+    else if (val_a.c > val_b.c) return 1;
+
+    else if (val_a.i > val_b.i) return -1;
+    else if (val_a.i < val_b.i) return 1;
+
+    else if (val_a.d < val_b.d) return -1;
+    else if (val_a.d > val_b.d) return 1;
+    return 0;
+}
+
+void test_integer_sort() { 
+
+    int empty_arr[1] = {0};
+    int empty_arr_expected[1] = {0};
+    isort(&empty_arr, 0, sizeof(int), intcmpfunc);
+    verify_sorted(empty_arr, 0, sizeof(int), intcmpfunc);
+    verify_expected(empty_arr, empty_arr_expected, 0, sizeof(int));
+
+    int single_arr[1] = {4};
+    int single_arr_expected[1] = {4};
+    isort(&single_arr, 1, sizeof(int), intcmpfunc);
+    verify_sorted(single_arr, 1, sizeof(int), intcmpfunc);
+    verify_expected(single_arr, single_arr_expected, 1, sizeof(int));
+
+
+    int double_arr[2] = {-1, -2};
+    int double_arr_expected[2] = {-2, -1};
+    isort(&double_arr, 2, sizeof(int), intcmpfunc);
+    verify_sorted(double_arr, 2, sizeof(int), intcmpfunc);
+    verify_expected(double_arr, double_arr_expected, 2, sizeof(int));
+
+    int multiple_arr[5] = {0, -4, 7, 5, 2};
+    int multiple_arr_expected[5] = {-4, 0, 2, 5, 7};
+    isort(&multiple_arr, 5, sizeof(int), intcmpfunc);
+    verify_sorted(multiple_arr, 5, sizeof(int), intcmpfunc);
+    verify_expected(multiple_arr, multiple_arr_expected, 5, sizeof(int));
+
+    char done[] = "test_integer_sort done\n";
+    serialWrite(COM1, (uint8_t *)(done), sizeof(done) - 1);
+}
+
+void test_struct_sort() {
+    Type case_a[2] = {{.c = 'c', .i = 5, .d = 0.3}, {.c = 'a', .i = 5, .d = 0.3}};
+    Type case_a_expected[2] = {{.c = 'a', .i = 5, .d = 0.3}, {.c = 'c', .i = 5, .d = 0.3}};
+
+    isort(&case_a, 2, sizeof(Type), &cmpfunc);
+    verify_sorted(&case_a, 2, sizeof(Type), &cmpfunc);
+    verify_expected(&case_a, &case_a_expected, 2, sizeof(Type));
+
+    char done[] = "test_struct_sort done\n";
+    serialWrite(COM1, (uint8_t *)(done), sizeof(done) - 1);
+}
+
+
+void test_main() {
+    test_integer_sort();
+    test_struct_sort();
+
+    char done[] = "test_sort done\n";
+    serialWrite(COM1, (uint8_t *)(done), sizeof(done) - 1);
+}

--- a/tests/src/lib/stdlib/test_sort.c
+++ b/tests/src/lib/stdlib/test_sort.c
@@ -1,8 +1,8 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "../../test_helper.h"
-#include "stdlib/stdlib.h"
-#include "stdlib/string.h"
+#include "stdlib.h"
+#include "string.h"
 
 void verify_sorted(void *base, size_t nel, size_t width, int (*compar)(const void *a, const void *b)) {
     ASSERT(nel >= 0);

--- a/tests/src/lib/stdlib/test_sort.c
+++ b/tests/src/lib/stdlib/test_sort.c
@@ -1,18 +1,21 @@
-#include <stddef.h>
-#include <stdint.h>
 #include "../../test_helper.h"
 #include "stdlib.h"
 #include "string.h"
 
-void verify_sorted(void *base, size_t nel, size_t width, int (*compar)(const void *a, const void *b)) {
+#include <stddef.h>
+#include <stdint.h>
+
+void verify_sorted(void *base, size_t nel, size_t width,
+                   int (*compar)(const void *a, const void *b)) {
     ASSERT(nel >= 0);
     ASSERT(width > 0);
-  
-    if (nel == 0 || nel == 1) return;
+
+    if (nel == 0 || nel == 1)
+        return;
 
     for (int i = 0; i < nel - 1; i++) {
         void *a = base + i * width;
-        void *b = base + (i+1) * width;
+        void *b = base + (i + 1) * width;
         ASSERT(compar(a, b) < 1);
     }
 }
@@ -21,7 +24,8 @@ void verify_expected(void *base_a, void *base_b, size_t nel, size_t width) {
     char *a = (char *)base_a;
     char *b = (char *)base_b;
     for (int i = 0; i < nel * width; i++) {
-        if (a[i] != b[i]) ASSERT(0);
+        if (a[i] != b[i])
+            ASSERT(0);
         return;
     }
 }
@@ -29,8 +33,10 @@ void verify_expected(void *base_a, void *base_b, size_t nel, size_t width) {
 int intcmpfunc(const void *a, const void *b) {
     int val_a = *(int *)a;
     int val_b = *(int *)b;
-    if (val_a < val_b) return -1;
-    else if (val_a == val_b) return 0;
+    if (val_a < val_b)
+        return -1;
+    else if (val_a == val_b)
+        return 0;
     return 1;
 }
 
@@ -43,18 +49,24 @@ typedef struct {
 int cmpfunc(const void *a, const void *b) {
     Type val_a = *(Type *)a;
     Type val_b = *(Type *)b;
-    if (val_a.c < val_b.c) return -1;
-    else if (val_a.c > val_b.c) return 1;
+    if (val_a.c < val_b.c)
+        return -1;
+    else if (val_a.c > val_b.c)
+        return 1;
 
-    else if (val_a.i > val_b.i) return -1;
-    else if (val_a.i < val_b.i) return 1;
+    else if (val_a.i > val_b.i)
+        return -1;
+    else if (val_a.i < val_b.i)
+        return 1;
 
-    else if (val_a.d < val_b.d) return -1;
-    else if (val_a.d > val_b.d) return 1;
+    else if (val_a.d < val_b.d)
+        return -1;
+    else if (val_a.d > val_b.d)
+        return 1;
     return 0;
 }
 
-void test_integer_sort() { 
+void test_integer_sort() {
     int empty_arr[1] = {0};
     int empty_arr_expected[1] = {0};
     isort(&empty_arr, 0, sizeof(int), intcmpfunc);
@@ -84,25 +96,23 @@ void test_integer_sort() {
 }
 
 void test_struct_sort() {
-    Type case_a[2] = {{.c = 'c', .i = 5, .d = 0.3}, {.c = 'a', .i = 5, .d = 0.3}};
-    Type case_a_expected[2] = {{.c = 'a', .i = 5, .d = 0.3}, {.c = 'c', .i = 5, .d = 0.3}};
+    Type case_a[2] = {{.c = 'c', .i = 5, .d = 0.3},
+                      {.c = 'a', .i = 5, .d = 0.3}};
+    Type case_a_expected[2] = {{.c = 'a', .i = 5, .d = 0.3},
+                               {.c = 'c', .i = 5, .d = 0.3}};
 
     isort(case_a, 2, sizeof(Type), cmpfunc);
     verify_sorted(case_a, 2, sizeof(Type), cmpfunc);
     verify_expected(case_a, case_a_expected, 2, sizeof(Type));
 
     Type case_b[5] = {
-        {.c = 'b', .i = 8, .d = -0.3},
-        {.c = 'b', .i = 8, .d = 0.3},
-        {.c = 'a', .i = 5, .d = 0.3},
-        {.c = 'b', .i = 8, .d = 2.7},
+        {.c = 'b', .i = 8, .d = -0.3}, {.c = 'b', .i = 8, .d = 0.3},
+        {.c = 'a', .i = 5, .d = 0.3},  {.c = 'b', .i = 8, .d = 2.7},
         {.c = 'b', .i = 5, .d = 0.3},
     };
     Type case_b_expected[5] = {
-        {.c = 'a', .i = 5, .d = -0.3},
-        {.c = 'b', .i = 5, .d = 0.3},
-        {.c = 'b', .i = 8, .d = -0.3},
-        {.c = 'b', .i = 8, .d = 0.3},
+        {.c = 'a', .i = 5, .d = -0.3}, {.c = 'b', .i = 5, .d = 0.3},
+        {.c = 'b', .i = 8, .d = -0.3}, {.c = 'b', .i = 8, .d = 0.3},
         {.c = 'b', .i = 8, .d = 2.7},
     };
 
@@ -113,7 +123,6 @@ void test_struct_sort() {
     char done[] = "test_struct_sort done\n";
     serialWrite(COM1, (uint8_t *)(done), sizeof(done) - 1);
 }
-
 
 void test_main() {
     test_integer_sort();

--- a/tests/src/lib/stdlib/test_sort.c
+++ b/tests/src/lib/stdlib/test_sort.c
@@ -55,7 +55,6 @@ int cmpfunc(const void *a, const void *b) {
 }
 
 void test_integer_sort() { 
-
     int empty_arr[1] = {0};
     int empty_arr_expected[1] = {0};
     isort(&empty_arr, 0, sizeof(int), intcmpfunc);
@@ -67,7 +66,6 @@ void test_integer_sort() {
     isort(&single_arr, 1, sizeof(int), intcmpfunc);
     verify_sorted(single_arr, 1, sizeof(int), intcmpfunc);
     verify_expected(single_arr, single_arr_expected, 1, sizeof(int));
-
 
     int double_arr[2] = {-1, -2};
     int double_arr_expected[2] = {-2, -1};
@@ -89,9 +87,28 @@ void test_struct_sort() {
     Type case_a[2] = {{.c = 'c', .i = 5, .d = 0.3}, {.c = 'a', .i = 5, .d = 0.3}};
     Type case_a_expected[2] = {{.c = 'a', .i = 5, .d = 0.3}, {.c = 'c', .i = 5, .d = 0.3}};
 
-    isort(&case_a, 2, sizeof(Type), &cmpfunc);
-    verify_sorted(&case_a, 2, sizeof(Type), &cmpfunc);
-    verify_expected(&case_a, &case_a_expected, 2, sizeof(Type));
+    isort(case_a, 2, sizeof(Type), cmpfunc);
+    verify_sorted(case_a, 2, sizeof(Type), cmpfunc);
+    verify_expected(case_a, case_a_expected, 2, sizeof(Type));
+
+    Type case_b[5] = {
+        {.c = 'b', .i = 8, .d = -0.3},
+        {.c = 'b', .i = 8, .d = 0.3},
+        {.c = 'a', .i = 5, .d = 0.3},
+        {.c = 'b', .i = 8, .d = 2.7},
+        {.c = 'b', .i = 5, .d = 0.3},
+    };
+    Type case_b_expected[5] = {
+        {.c = 'a', .i = 5, .d = -0.3},
+        {.c = 'b', .i = 5, .d = 0.3},
+        {.c = 'b', .i = 8, .d = -0.3},
+        {.c = 'b', .i = 8, .d = 0.3},
+        {.c = 'b', .i = 8, .d = 2.7},
+    };
+
+    isort(case_b, 5, sizeof(Type), cmpfunc);
+    verify_sorted(case_b, 5, sizeof(Type), cmpfunc);
+    verify_expected(case_b, case_b_expected, 5, sizeof(Type));
 
     char done[] = "test_struct_sort done\n";
     serialWrite(COM1, (uint8_t *)(done), sizeof(done) - 1);

--- a/tests/src/lib/stdlib/test_stdio.c
+++ b/tests/src/lib/stdlib/test_stdio.c
@@ -1,6 +1,6 @@
 #include "../../test_helper.h"
-#include "stdlib/stdio.h"
-#include "stdlib/string.h"
+#include "stdio.h"
+#include "string.h"
 
 #include <stdarg.h>
 

--- a/tests/src/lib/stdlib/test_stdlib.c
+++ b/tests/src/lib/stdlib/test_stdlib.c
@@ -1,6 +1,6 @@
 #include "../../test_helper.h"
-#include "stdlib/stdlib.h"
-#include "stdlib/string.h"
+#include "stdlib.h"
+#include "string.h"
 
 #define BUFSZ 100
 

--- a/tests/src/lib/stdlib/test_string.c
+++ b/tests/src/lib/stdlib/test_string.c
@@ -1,5 +1,5 @@
 #include "../../test_helper.h"
-#include "stdlib/string.h"
+#include "string.h"
 
 #define BUFSZ                                                                  \
     100 // the size of string compare buffers (to detect buffer overflow)

--- a/tests/src/lib/stdlib/test_string.c
+++ b/tests/src/lib/stdlib/test_string.c
@@ -68,6 +68,31 @@ void test_strcpy_s(void *in, int sz, int cmpsz) {
     }
 }
 
+void test_memswap(void *in_a, void *in_b, int sz) {
+    ASSERT(sz > 0);
+    char *a = (char *)in_a;
+    char *b = (char *)in_b;
+    char swap_a[BUFSZ + 1];
+    char swap_b[BUFSZ + 1];
+    swap_a[sz] = 'a';
+    swap_b[sz] = 'b';
+
+    memcpy(swap_a, a, BUFSZ);
+    memcpy(swap_b, b, BUFSZ);
+
+    memswap(swap_a, swap_b, sz);
+    
+    for (int i = 0; i < sz; i++) {
+        ASSERT(a[i] == swap_b[i]);
+        ASSERT(b[i] == swap_a[i]);
+    }
+
+    for (int i = sz; i < BUFSZ; i++) {
+        ASSERT(swap_a[i] == a[i]);
+        ASSERT(swap_b[i] == b[i]);
+    }
+}
+
 int test_main() {
     test_strnlen_s("makeopensource!", 100, 15);
     test_strnlen_s("", 100, 0);
@@ -96,6 +121,8 @@ int test_main() {
     test_strcpy_s("copy\0", 100, 5);
     test_strcpy_s("makeopensource\0", 8, 8);
     test_strcpy_s("don't copy me", 0, 0);
+
+    test_memswap("12345678", "87654321", 8);
 
     char done[] = "test_string done\n";
     serialWrite(COM1, (uint8_t *)(done), sizeof(done) - 1);

--- a/tests/src/lib/stdlib/test_string.c
+++ b/tests/src/lib/stdlib/test_string.c
@@ -81,7 +81,7 @@ void test_memswap(void *in_a, void *in_b, int sz) {
     memcpy(swap_b, b, BUFSZ);
 
     memswap(swap_a, swap_b, sz);
-    
+
     for (int i = 0; i < sz; i++) {
         ASSERT(a[i] == swap_b[i]);
         ASSERT(b[i] == swap_a[i]);


### PR DESCRIPTION
# Description

I added insertion sort into stdlib (and made stdlib a common library for all c files to access). I also included thorough tests that demonstrate the type-agnostic approach (which C uses to implement qsort and heapsort). This function is useful in the issue #30 (Mallocation) because a small number of structures need to be sorted in-place.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

### Testing 

I created tests for sorting arrays of integers, and custom type `Type` which includes an int, float, and char. These two types of arrays have their own `compar` function which compares two elements and returns an `int` of `-1, 0, 1` indicating the intended order. The test then sorts the arrays, and checks that the corresponding array follows the `compar` function ordering, and has the same elements as is expected.

**Test Configuration**:
* Hardware
* OS

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
